### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting assignment

### DIFF
--- a/packages/helpers/src/set-field.ts
+++ b/packages/helpers/src/set-field.ts
@@ -35,6 +35,13 @@ export function setField<
       ? toPath(path)
       : [path];
 
+  // Validate resolvedPath to prevent prototype pollution
+  for (const key of resolvedPath) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      throw new Error('Invalid key in path: ' + key);
+    }
+  }
+
   let current: any = object;
   for (let i = 0; i < resolvedPath.length - 1; i++) {
     const key = resolvedPath[i];


### PR DESCRIPTION
Potential fix for [https://github.com/storm-software/stryke/security/code-scanning/2](https://github.com/storm-software/stryke/security/code-scanning/2)

To fix the problem, we need to ensure that the `path` parameter does not contain any malicious values that could lead to prototype pollution. One way to achieve this is by checking if any of the keys in the `resolvedPath` array are `__proto__`, `constructor`, or `prototype`, and rejecting such inputs. This can be done by adding a validation step before using the keys to access and modify the `current` object.

We will add a validation step after resolving the `path` to ensure that none of the keys in the `resolvedPath` array are `__proto__`, `constructor`, or `prototype`. If any such key is found, we will throw an error to prevent prototype pollution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
